### PR TITLE
feat: Improve import guard and add Python 3.12 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,9 @@ packages = [{ include = "src" }]
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 
@@ -22,9 +21,6 @@ flake8 = "^7.1.0"
 gitpython = "^3.1.43"
 python-dotenv = "^1.0.1"
 toml = "^0.10.2"
-
-[tool.poetry.plugins."flake8.extension"]
-CPE = "src.main:Flake8ImportGuard"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.5.5"
@@ -40,7 +36,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 testpaths = 'tests'
 pythonpath = "."
-addopts = '-p no:warnings'                         # disable pytest warnings
+addopts = '-p no:warnings'  # disable pytest warnings
 log_format = '%(name)s %(levelname)s: %(message)s'
 
 # ruff global settings
@@ -56,12 +52,21 @@ line-length = 80
 # P: Pylint
 # PT: flake8-pytest-style
 preview = true
-select = ['I', 'F', 'E', 'W', 'PL', 'PT']
+select = ['I', 'F', 'W', 'PL', 'PT']
+
+[tool.ruff.lint.pycodestyle]
+ignore-overlong-task-comments = true
+max-doc-length = 120
 
 # formatter
 [tool.ruff.format]
 preview = true
 quote-style = 'double'
+docstring-code-format = true
+
+# flake8-import-guard
+[tool.poetry.plugins."flake8.extension"]
+CPE = "src.main:Flake8ImportGuard"
 
 [tool.flake8-import-guard]
 forbidden_imports = ["load_dotenv", "subprocess"]

--- a/src/main.py
+++ b/src/main.py
@@ -8,16 +8,65 @@ from flake8.options.manager import OptionManager
 
 
 class Flake8ImportGuard:
+    """
+    A Flake8 plugin to enforce import restrictions in Python code.
+
+    This plugin checks for forbidden imports in Python files and reports violations.
+    It supports configuration through Flake8's standard configuration system and pyproject.toml.
+    """
+
     name = "flake8-import-guard"
     version = "0.1.0"
+    forbidden_imports: List[str] = []
 
     def __init__(self, tree: ast.AST, filename: str):
+        """
+        Initialize the Flake8ImportGuard instance.
+
+        Args:
+            tree (ast.AST): The AST of the Python file to check.
+            filename (str): The name of the file being checked.
+        """
         self.tree = tree
         self.filename = filename
-        self.config = self.load_config()
 
     @staticmethod
-    def load_config() -> Dict[str, List[str]]:
+    def add_options(option_manager: OptionManager) -> None:
+        """
+        Add Flake8 command-line options for this plugin.
+
+        Args:
+            option_manager (OptionManager): Flake8's OptionManager instance.
+        """
+        option_manager.add_option(
+            "--forbidden-imports",
+            default="",
+            parse_from_config=True,
+            comma_separated_list=True,
+            help="Comma-separated list of forbidden imports",
+        )
+
+    @classmethod
+    def parse_options(cls, options: Any) -> None:
+        """
+        Parse the options provided by Flake8 and pyproject.toml.
+
+        Args:
+            options (Any): The options object provided by Flake8.
+        """
+        cls.forbidden_imports = options.forbidden_imports
+        pyproject_config = cls.load_pyproject_config()
+        if "forbidden_imports" in pyproject_config:
+            cls.forbidden_imports.extend(pyproject_config["forbidden_imports"])
+
+    @staticmethod
+    def load_pyproject_config() -> Dict[str, List[str]]:
+        """
+        Load configuration from pyproject.toml file.
+
+        Returns:
+            Dict[str, List[str]]: Configuration dictionary from pyproject.toml.
+        """
         try:
             with open("pyproject.toml", "r", encoding="utf-8") as f:
                 config = toml.load(f)
@@ -25,89 +74,17 @@ class Flake8ImportGuard:
         except FileNotFoundError:
             return {}
 
-    @staticmethod
-    def add_options(option_manager: OptionManager) -> None:
-        option_manager.add_option(
-            "--enforce-patterns",
-            default="",
-            parse_from_config=True,
-            comma_separated_list=True,
-            help="Comma-separated list of import patterns to enforce",
-        )
-
-    @classmethod
-    def parse_options(cls, options: Any) -> None:
-        cls.enforce_patterns = options.enforce_patterns
-
-    def run(self) -> Generator[Tuple[int, int, str, type], None, None]:
-        forbidden_imports = self.config.get("forbidden_imports", [])
-        if not forbidden_imports:
-            return
-
-        # 新規ファイルかどうかを確認
-        is_new_file = not os.path.exists(self.filename)
-        if not is_new_file:
-            git_check = subprocess.run(
-                ["git", "ls-files", "--error-unmatch", self.filename],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            is_new_file = git_check.returncode != 0
-
-        current_imports = self.get_imports(self.tree)
-
-        if is_new_file:
-            # 新規ファイルの場合は全てのimportをチェック
-            imports_to_check = current_imports
-            previous_imports = set()
-        else:
-            # 既存ファイルの場合は前回のコミットの状態を取得
-            try:
-                result = subprocess.run(
-                    ["git", "show", f"HEAD:{self.filename}"],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                previous_content = result.stdout
-                previous_tree = ast.parse(previous_content)
-                previous_imports = self.get_imports(previous_tree)
-                imports_to_check = current_imports - previous_imports
-            except subprocess.CalledProcessError:
-                # Gitコマンドが失敗した場合（例：初回コミット前）は
-                # 全てのimportをチェック
-                imports_to_check = current_imports
-                previous_imports = set()
-
-        # デバッグ用の出力
-        print(f"Is new file: {is_new_file}")
-        print(f"Current imports: {current_imports}")
-        print(f"Previous imports: {previous_imports}")
-        print(f"Imports to check: {imports_to_check}")
-
-        for node in ast.walk(self.tree):
-            if not isinstance(node, (ast.Import, ast.ImportFrom)):
-                continue
-            for alias in node.names:
-                import_name = (
-                    alias.name
-                    if isinstance(node, ast.Import)
-                    else (f"{node.module}.{alias.name}")
-                )
-                if import_name in imports_to_check:
-                    for forbidden in forbidden_imports:
-                        if forbidden in import_name:
-                            yield (
-                                node.lineno,
-                                node.col_offset,
-                                f"CPE001 Forbidden import found: {import_name}",
-                                type(self),
-                            )
-                            break  # 同じimportに対して複数の違反を報告しない
-
     @classmethod
     def get_imports(cls, tree: ast.AST) -> Set[str]:
+        """
+        Extract all imports from the given AST.
+
+        Args:
+            tree (ast.AST): The AST to extract imports from.
+
+        Returns:
+            Set[str]: A set of all imports found in the AST.
+        """
         imports = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
@@ -121,5 +98,72 @@ class Flake8ImportGuard:
                     imports.update(alias.name for alias in node.names)
         return imports
 
+    def run(self) -> Generator[Tuple[int, int, str, type], None, None]:
+        """
+        Run the import check on the current file.
+
+        Yields:
+            Tuple[int, int, str, type]: Violations found in the format (line, col, message, type).
+        """
+        if not self.forbidden_imports:
+            return
+
+        is_new_file = not os.path.exists(self.filename)
+        if not is_new_file:
+            git_check = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", self.filename],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            is_new_file = git_check.returncode != 0
+
+        current_imports = self.get_imports(self.tree)
+
+        if is_new_file:
+            imports_to_check = current_imports
+            previous_imports = set()
+        else:
+            try:
+                result = subprocess.run(
+                    ["git", "show", f"HEAD:{self.filename}"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                previous_content = result.stdout
+                previous_tree = ast.parse(previous_content)
+                previous_imports = self.get_imports(previous_tree)
+                imports_to_check = current_imports - previous_imports
+            except subprocess.CalledProcessError:
+                imports_to_check = current_imports
+                previous_imports = set()
+
+        for node in ast.walk(self.tree):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            for alias in node.names:
+                import_name = (
+                    alias.name
+                    if isinstance(node, ast.Import)
+                    else (f"{node.module}.{alias.name}")
+                )
+                if import_name in imports_to_check:
+                    for forbidden in self.forbidden_imports:
+                        if forbidden in import_name:
+                            yield (
+                                node.lineno,
+                                node.col_offset,
+                                f"CPE001 Forbidden import found: {import_name}",
+                                type(self),
+                            )
+                            break
+
     def __iter__(self):
+        """
+        Make the class iterable, returning the run generator.
+
+        Returns:
+            Generator: The run method's generator.
+        """
         return self.run()


### PR DESCRIPTION
- Pythonバージョンのサポート範囲を3.10、3.11、3.12に更新
- flake8-import-guardプラグインの設定をpyproject.tomlから削除後、適切に再配置
- Flake8ImportGuardクラスに詳細なドキュメントコメントを追加し、構成読み込みロジックをリファクタリング
- Flake8ImportGuardクラスのconfig属性を削除し、クラス変数であるforbidden_importsを導入
- Flake8ImportGuardクラスのrunメソッドを強化し、違反チェックロジックを改善
- テストコードをリファクタリングし、ドキュメントコメントを追加し、新しいメソッドおよびオプションに対応