### PR TITLE
feat: Add contributing guidelines and README for Flake8 Import Guard

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -45,3 +45,4 @@ ignore =
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 extend-ignore = E203
 filename = *.py
+forbidden_imports = load_dotenv,subprocess

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Flake8 Import Guard
+
+We're thrilled that you're interested in contributing to Flake8 Import Guard! This document provides guidelines for contributions to make the process smooth and effective for everyone involved.
+
+## Code of Conduct
+
+By participating in this project, you are expected to uphold our Code of Conduct. Please report unacceptable behavior to [project_email@example.com].
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+- Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/yourusername/flake8-import-guard/issues).
+- If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/yourusername/flake8-import-guard/issues/new). Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+### Suggesting Enhancements
+
+- Open a new issue with a clear title and detailed description of the suggested enhancement.
+- Provide examples and explain why this enhancement would be useful to most users.
+
+### Pull Requests
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the `README.md`.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+## Development Setup
+
+To set up Flake8 Import Guard for development:
+
+1. Fork and clone the repo.
+2. Install dependencies and Activate the virtual environment.
+   ```
+   make install
+   ```
+3. Run tests to ensure everything is set up correctly:
+   ```
+   make all
+
+   or
+
+   make output_cov
+   ```
+
+> [!NOTE]
+> This project uses `Makefile` as a task runner. You need to set up your environment to be able to run the `make` command.
+
+## Styleguides
+
+### Git Commit Messages
+
+- Please comply with the [Semantic Commit Message](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and [Commit Message Guideline](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)
+
+### Python Styleguide
+
+- Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/).
+- This is achieved using the `ruff` Linter and Formatter.
+- Use type hints where possible.
+
+### Documentation Styleguide
+
+- Use [Markdown](https://daringfireball.net/projects/markdown/) for documentation.
+- Reference functions and classes appropriately.
+
+## Additional Notes
+
+### Issue and Pull Request Labels
+
+- `bug`: Something isn't working
+- `enhancement`: New feature or request
+- `documentation`: Improvements or additions to documentation
+- `good first issue`: Good for newcomers
+
+Thank you for contributing to Flake8 Import Guard!

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ lint:
 test:
 	poetry run pytest
 
-.PHONY: output_coverage
-output_coverage:
+.PHONY: output_cov
+output_cov:
 	@rm -rf htmlcov
 	@mkdir -p htmlcov
 	poetry run coverage run -m pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,128 @@
+# Flake8 Import Guard
+
+Flake8 Import Guard is a Flake8 plugin that helps enforce import restrictions in your Python projects. It allows you to specify forbidden imports and detects their usage in your codebase, focusing on newly added imports in version-controlled files.
+
+## Features
+
+- Detects forbidden imports in Python files
+- Supports configuration through Flake8's standard configuration system and `pyproject.toml`
+- Focuses on newly added imports, ignoring existing ones in version-controlled files
+- Easy integration with existing Flake8 setups
+
+## Installation
+
+You can install Flake8 Import Guard using pip.
+
+```
+pip install flake8-import-guard
+```
+
+## Usage
+
+Once installed, Flake8 Import Guard will automatically be used by Flake8. You can run it using the standard Flake8 command.
+
+```
+flake8 path/to/your/code
+```
+
+## Configuration
+
+You can configure Flake8 Import Guard using Flake8's standard configuration system or through `pyproject.toml`.
+
+### Using Flake8 Configuration
+
+Add the following to your `.flake8` file:
+
+```ini
+[flake8]
+forbidden_imports = load_dotenv,subprocess
+```
+
+### Using pyproject.toml
+
+Add the following to your `pyproject.toml` file:
+
+```toml
+[tool.flake8-import-guard]
+forbidden_imports = [
+    "load_dotenv",
+    "subprocess"
+]
+```
+
+## Example
+
+### Configuration
+
+Let's say you have the following configuration in your `.flake8` file:
+
+```ini
+[flake8]
+forbidden_imports = load_dotenv,subprocess
+```
+
+### Sample Python File
+
+Consider the following Python file:
+
+```python
+# test_file.py
+import os
+from datetime import datetime
+
+from subprocess import check_output  # Violation Module
+
+from dotenv import load_dotenv       # Violation Module
+
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()
+```
+
+### Execution and Result
+
+When you run Flake8 on this file, you'll get the following output:
+
+```console
+$ flake8 test_file.py
+test_file.py:4:1: CPE001 Forbidden import found: subprocess.check_output
+test_file.py:6:1: CPE001 Forbidden import found: dotenv.load_dotenv
+```
+
+## How It Works
+
+Flake8 Import Guard uses Git to detect changes in your codebase:
+
+1. For new files, it checks all imports against the forbidden list.
+2. For existing files, it compares the current version with the last committed version to identify newly added imports.
+3. Only newly added imports that match the forbidden list are reported as violations.
+
+## Capabilities and Limitations
+
+### What It Can Do
+
+- Detect newly added forbidden imports in both new and existing files
+- Work with Git-versioned projects
+- Configure forbidden imports through Flake8 config or pyproject.toml
+- Integrate seamlessly with existing Flake8 workflows
+
+### What It Cannot Do
+
+- Work in non-Git environments
+- Identify removed or modified imports (focus is on new additions only)
+- Detect indirect imports (e.g., imports within imported modules)
+
+## Error Codes
+
+- CPE001: Forbidden import found
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+See [CONTRIBUTING.md](https://github.com/K-dash/flake8-import-guard/blob/main/CONTRIBUTING.md) to get an idea of how contributions work.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
- 新しい `CONTRIBUTING.md` ファイルを作成し、貢献方法についてのガイドラインを提供しました
- `Makefile` のターゲット名を `output_cov` に変更しました
- Flake8 Import Guard の機能、使用方法、設定方法などを詳しく説明する `README.md` を追加しました
- テスト実行およびカバレッジ出力コマンドを `Makefile` のタスクとして簡素化しました