### PR TITLE
feat: Add build and test workflows, update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+test_env/
 
 # Spyder project settings
 .spyderproject

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,16 @@ clean:
 	rm -f .coverage
 	rm -f .coverage.*
 
+.PHONY: build
+build:
+	poetry build
+	python -m venv test_env
+	source test_env/bin/activate
+
+.PHONY: build_test
+build_test:
+	pip install dist/flake8_import_guard-0.1.0-py3-none-any.whl
+	flake8 --version
+
 .PHONY: all
 all: format lint test

--- a/poetry.lock
+++ b/poetry.lock
@@ -83,6 +83,9 @@ files = [
     {file = "coverage-7.6.0.tar.gz", hash = "sha256:289cc803fa1dc901f84701ac10c9ee873619320f2f9aff38794db4a4a0268d51"},
 ]
 
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
 [package.extras]
 toml = ["tomli"]
 
@@ -96,6 +99,20 @@ files = [
     {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
     {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
 ]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
@@ -303,9 +320,11 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -452,6 +471,17 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.26.3"
 description = "Virtual Python Environment builder"
@@ -473,5 +503,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "04842bc3622977cb09e427692d8ccd7c69ccd0b55af31939f8fa114b7d6999fc"
+python-versions = "^3.9"
+content-hash = "41e24925cbe644b6cc64a3e9695b74f34b521d8ee98ea1da09bd78e28c9a75aa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,24 @@ description = ""
 authors = ["K'  <51281148+K-dash@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/K-dash/flake8-import-guard"
+repository = "https://github.com/K-dash/flake8-import-guard"
+keywords = ["flake8", "plugin", "import", "linter"]
 packages = [{ include = "src" }]
 classifiers = [
+    "Framework :: Flake8",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Quality Assurance",
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.9"
 flake8 = "^7.1.0"
 gitpython = "^3.1.43"
 python-dotenv = "^1.0.1"
@@ -29,7 +35,7 @@ pytest = "^8.3.2"
 pytest-cov = "^5.0.0"
 
 [build-system]
-requires = ["poetry-core", "wheel"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 # pytest settings
@@ -68,5 +74,5 @@ docstring-code-format = true
 [tool.poetry.plugins."flake8.extension"]
 CPE = "src.main:Flake8ImportGuard"
 
-[tool.flake8-import-guard]
-forbidden_imports = ["load_dotenv", "subprocess"]
+# [tool.flake8-import-guard]
+# forbidden_imports = ["load_dotenv", "subprocess"]

--- a/tests/sample.py
+++ b/tests/sample.py
@@ -1,0 +1,17 @@
+import os
+from datetime import datetime
+from subprocess import check_output
+
+from dotenv import load_dotenv
+
+
+def main():
+    print(os.environ.get("TEST"))
+    print(datetime.now())
+    print(type(check_output))
+    print(type(load_dotenv))
+    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- `.gitignore`に`test_env/`を追加し、テスト用の仮想環境を構築できるようにした
- `Makefile`に`build`および`build_test`ターゲットを追加して、ビルドとテストの自動化を強化
- `poetry.lock`に新しい依存関係（exceptiongroupおよびtomli）を追加し、Pythonバージョンの下位互換性を向上
- `pyproject.toml`にホームページ、リポジトリ、キーワードなどのメタ情報を追加し、プロジェクトの情報を充実化
- テスト用のサンプルスクリプト（`sample.py`）を追加し、import-guardの手動確認をできるようにした