### PR TITLE
chore: change package ecosystem in dependabot.yml from “pip” to “uv” …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
-    versioning-strategy: "lockfile-only"
+    target-branch: "main"


### PR DESCRIPTION
close: https://github.com/K-dash/flake8-import-guard/issues/41