### PR TITLE
Fix relative import detection in plugin

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -143,11 +143,14 @@ class Flake8ImportGuard:
             if not isinstance(node, (ast.Import, ast.ImportFrom)):
                 continue
             for alias in node.names:
-                import_name = (
-                    alias.name
-                    if isinstance(node, ast.Import)
-                    else (f"{node.module}.{alias.name}")
-                )
+                if isinstance(node, ast.Import):
+                    import_name = alias.name
+                else:
+                    import_name = (
+                        f"{node.module}.{alias.name}"
+                        if node.module
+                        else alias.name
+                    )
                 if import_name not in imports_to_check:
                     continue
                 for forbidden in self.forbidden_imports:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,6 +43,18 @@ def test_run_with_forbidden_import(enforcer):
     )
 
 
+def test_run_with_relative_forbidden_import(enforcer):
+    """Test the run method with a forbidden relative import."""
+    code = "from . import load_dotenv"
+    test_enforcer = enforcer(code)
+    Flake8ImportGuard.forbidden_imports = ["load_dotenv"]
+    violations = list(test_enforcer.run())
+    assert len(violations) == 1
+    assert violations[0][2] == (
+        "CPE001 Forbidden import found: load_dotenv"
+    )
+
+
 def test_run_with_allowed_import(enforcer):
     """Test the run method with an allowed import."""
     code = "import os"


### PR DESCRIPTION
## Summary
- handle ImportFrom nodes with no module
- test relative forbidden imports

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*