### PR TITLE
chore: migrate from Dependabot to Renovate Bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["after 10pm every weekday", "before 5am every weekday", "every weekend"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Group dependency-groups updates",
+      "matchManagers": ["pep735"],
+      "groupName": "dependency-groups"
+    },
+    {
+      "description": "Group Python dev dependencies",
+      "matchDepTypes": ["dev"],
+      "groupName": "python dev dependencies"
+    }
+  ],
+  "rangeStrategy": "auto",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 5am on monday"]
+  }
+}


### PR DESCRIPTION
## Summary
- DependabotからRenovate Botに移行し、PEP 735 dependency-groupsサポートを追加

## Changes
- `.github/dependabot.yml`を削除
- `.github/renovate.json`を追加
- PEP 735 dependency-groups対応を設定
- マイナー・パッチ更新の自動マージを有効化
- 依存関係ダッシュボードとロックファイルメンテナンスを設定
- タイムゾーンとスケジュール設定（Asia/Tokyo、平日夜間と週末）

## Motivation
Dependabotは現在PEP 735のdependency-groupsをサポートしていないため、`pyproject.toml`の`[dependency-groups]`セクションの依存関係が自動更新されていませんでした。Renovate BotはすでにPEP 735をサポートしており、より柔軟な設定が可能です。

## Test plan
- [x] Renovate Bot設定ファイルの構文チェック
- [ ] GitHub AppとしてRenovate Botをインストール
- [ ] Onboarding PRの確認とマージ
- [ ] Dependency Dashboard Issueの作成確認
- [ ] dependency-groups依存関係の更新PR作成確認

🤖 Generated with [Claude Code](https://claude.ai/code)