### PR TITLE
fix: correct Renovate configuration for dependency-groups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "description": "Group dependency-groups updates",
-      "matchManagers": ["pep735"],
+      "matchDepTypes": ["dependency-groups"],
       "groupName": "dependency-groups"
     },
     {


### PR DESCRIPTION
## Summary
Fix Renovate Bot configuration error by replacing unsupported `pep735` manager with correct `dependency-groups` depType.

## Problem
Renovate Bot was showing the following error:
```
packageRules: You have included an unsupported manager in a package rule. Your list: pep735. Supported managers are: (ansible, ansible-galaxy, argocd, asdf, azure-pipelines, ...)
```

## Solution
- Replace `"matchManagers": ["pep735"]` with `"matchDepTypes": ["dependency-groups"]`
- PEP 735 dependency-groups are automatically detected and handled by the `pep621` manager
- No special configuration is required for PEP 735 support

## Changes
- Update `.github/renovate.json` to use correct package rule syntax
- Remove reference to non-existent `pep735` manager

## Test plan
- [x] Verify Renovate configuration syntax is valid
- [ ] Confirm repository problems are resolved in Renovate dashboard
- [ ] Verify dependency-groups dependencies are properly detected and updated


Close https://github.com/K-dash/flake8-import-guard/issues/56