### PR TITLE
chore: add Python 3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [


### PR DESCRIPTION
I don't believe any additional changes are needed here other than adding the 3.13 Trove classifier for PyPI. Tests are already being run up to 3.13 in GitHub Actions, and pass on 3.13 on my machine.

Unless I'm missing something, this project already supports 3.13.

Closes #93.